### PR TITLE
Add admonition pointing readers to the glass-box-umap package

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Please see [SETUP.qmd](pages/SETUP.qmd).
 
 **NOTE**: you must run the following command to properly clone the submodule with the repo:
 ```
-git clone https://github.com/Arcadia-Science/glass-box-umap.git --recurse-submodules
+git clone https://github.com/Arcadia-Science/glass-box-umap-notebook-pub.git --recurse-submodules
 ```
 
 If you already have the repo without the submodule from the normal clone command, run this to add the submodule:

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ This code repository contains or points to all materials required for creating a
 
 The publication is hosted at [this URL](https://arcadia-science.github.io/glass-box-umap-notebook-pub/).
 
+> [!IMPORTANT]
+> Since this publication, we've released [`glass-box-umap`](https://glass-box-umap.readthedocs.io), a Python package that implements the method described here. If you want to apply Glass Box UMAP to your own data, head there.
+
 ## Data Description
 
 We apply the glass box UMAP approach to feature interpretation to the human bone marrow gene expression data of [A sandbox for prediction and integration of DNA, RNA, and proteins in single cells by Luecken et al. 2021](https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE194122), which is included as the example dataset in ScanPy. 

--- a/index.ipynb
+++ b/index.ipynb
@@ -18,6 +18,16 @@
   },
   {
    "cell_type": "markdown",
+   "id": "d5a69069",
+   "metadata": {},
+   "source": [
+    ":::{.callout-important title=\"A Python package is now available\"}\n",
+    "Since this publication, we've released [`glass-box-umap`](https://glass-box-umap.readthedocs.io), a Python package that implements the method described here. To apply Glass Box UMAP to your own data, install the package rather than copying code snippets from this notebook. Documentation, examples, and installation instructions are available at [glass-box-umap.readthedocs.io](https://glass-box-umap.readthedocs.io).\n",
+    ":::"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "ed6e1947",
    "metadata": {},
    "source": [


### PR DESCRIPTION
## Summary
- Add a prominent `.callout-important` admonition near the top of `index.ipynb` directing readers to the [`glass-box-umap`](https://glass-box-umap.readthedocs.io) Python package rather than copying snippets from this notebook.
- Fix a stale clone URL in `README.md` that still referenced the package repo (`glass-box-umap.git`) instead of this pub's repo (`glass-box-umap-notebook-pub.git`).